### PR TITLE
Clarify FFI reporting units and confidence wording

### DIFF
--- a/SURF_Summary.tex
+++ b/SURF_Summary.tex
@@ -16,10 +16,10 @@ John McGuigan \quad Advisor: Sherwood Richers\\
 Department of Physics and Astronomy, University of Tennessee, Knoxville\\
 
 \textbf{Abstract.}
-Core-collapse supernovae and neutron star mergers host extreme conditions where neutrino self-interactions can trigger \emph{fast flavor instabilities} (FFI) on cm/ns scales.
+Core-collapse supernovae and neutron star mergers host extreme conditions where neutrino self-interactions can trigger \emph{fast flavor instabilities} (FFI) on centimeter-per-nanosecond scales.
 I trained heavily regularized multi-layer neural networks (MLNNs; 4--6 layers, hundreds of neurons wide) in PyTorch on $\sim 8\times 10^5$ labeled snapshots spanning seeded-unstable, guaranteed-stable, and neutron-star-merger (NSM) cases.
 After a systematic hyperparameter search (dropout, batch normalization, weight decay, batch size, learning rate schedules, and early stopping) and class-weighted training to address the $\sim$5--6\% unstable minority class, the best model reaches $F_1 \approx 0.95$ on held-out data while remaining small enough for in-situ use in simulation codes.
-The network outputs a calibrated $P(\mathrm{FFI}\mid x)$ per grid cell, replacing an expensive dispersion solve with negligible overhead in principle; integration tests and wall-time benchmarks are planned for production hydrodynamics runs.
+The network outputs a calibrated FFI confidence per grid cell, replacing an expensive dispersion solve with negligible overhead in principle; integration tests and wall-time benchmarks are planned for production hydrodynamics runs.
 
 \subsection*{Background \& Physics}
 Neutrinos carry away $\gtrsim 99\%$ of the gravitational binding energy in core collapse, and their angular electron-lepton-number (ELN) spectra can admit crossings that seed FFI.
@@ -31,7 +31,7 @@ with the self-interaction term
 \begin{equation*}
 H_{\nu\nu} \propto \mu \!\int (1-\cos\theta)\, G(\mathbf{v})\, d\Omega,
 \end{equation*}
-where $G(\mathbf{v})$ is the ELN angular distribution and $\mu$ sets the interaction scale. The presence of ELN crossings can drive flavor conversion on microscopic (cm/ns) scales that are numerically difficult to resolve directly across all cells in neutrino transport simulations.
+where $G(\mathbf{v})$ is the ELN angular distribution and $\mu$ sets the interaction scale. The presence of ELN crossings can drive flavor conversion on microscopic (centimeter-per-nanosecond) scales that are numerically difficult to resolve directly across all cells in neutrino transport simulations.
 
 \subsection*{Data \& Features}
 Labeled examples consist of $\sim 8\times 10^5$ per-cell snapshots (stable versus FFI-unstable) drawn from CCSN and NSM datasets.
@@ -46,7 +46,7 @@ Training employs class-weighted binary cross-entropy with $L_2$ regularization,
 \end{equation*}
 and is optimized with AdamW and a cosine/step learning-rate schedule.
 Batch sizes of $4\,096$--$16\,384$ start near $3\times 10^{-3}$ learning rate with decay and early stopping to prevent overfitting.
-After training, the classification cutoff on $P(\mathrm{FFI}\mid x)$ is swept to maximize the $F_1$ score, balancing precision and recall.
+After training, the classification cutoff on the FFI confidence is swept to maximize the $F_1$ score, balancing precision and recall.
 
 \subsection*{Validation \& Reproducibility}
 Precision, recall, and $F_1 = \frac{2PR}{P+R}$ are measured on a held-out test set.
@@ -67,7 +67,7 @@ I also trained smaller variants (fewer layers and narrower widths) to minimize i
 
 \subsection*{Deployment Plan \& Impact}
 For in-situ prediction, the model is exported to TorchScript and run as batch per-cell inference on CPU or GPU within radiation-hydrodynamics codes.
-The resulting $P(\mathrm{FFI}\mid x)$ serves as a flag or risk score that enables flavor-aware closures or triggers higher-fidelity solvers only where instability is likely.
+The resulting FFI confidence serves as a flag or risk score that enables flavor-aware closures or triggers higher-fidelity solvers only where instability is likely.
 The architecture is constrained for real-time deployability, and end-to-end wall-time benchmarks on production grids are the next step.
 
 \subsection*{Progress to Date}


### PR DESCRIPTION
## Summary
- Spell out centimeter-per-nanosecond scales in abstract and background
- Replace `P(FFI|x)` probability notation with more accessible FFI confidence wording

## Testing
- `pdflatex -interaction=nonstopmode SURF_Summary.tex` *(fails: File `booktabs.sty` not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de7d4cb708321ad82c1fc052cdb6a